### PR TITLE
Support playing through connected audio accessory

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -233,11 +233,13 @@ RCT_EXPORT_METHOD(getCurrentTime:(nonnull NSNumber*)key
 RCT_EXPORT_METHOD(setSpeakerphoneOn:(BOOL)enabled) {
   AVAudioSession *session = [AVAudioSession sharedInstance];
   NSError *error = nil;
+  AVAudioSessionCategoryOptions categoryOptions = [session categoryOptions];
   if (enabled) {
-    [session  overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error];
+    categoryOptions = categoryOptions | AVAudioSessionCategoryOptionDefaultToSpeaker;
   } else {
-    [session  overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error];
+    categoryOptions = categoryOptions & ~AVAudioSessionCategoryOptionDefaultToSpeaker;
   }
+  [session setCategory: AVAudioSessionCategoryPlayAndRecord withOptions: categoryOptions error: &error];
 }
 
 RCT_REMAP_METHOD(isHeadsetPluggedIn,


### PR DESCRIPTION
- It closes https://github.com/hayanmind/mimiking-rn/issues/492.
- `AVAudioSessionCategoryPlayAndRecord` play sound through earpiece.
- Option `AVAudioSessionCategoryOptionDefaultToSpeaker` play sound through speaker or connected audio accessory.
- Lagacy code ` [session  overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error]` seem to force play through speaker even though the audio accessory is connected. 