### PR TITLE
Fix auto playing when setting speed

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -329,7 +329,12 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
       MediaPlayer player = this.playerPool.get(key);
       if (player != null) {
-        player.setPlaybackParams(player.getPlaybackParams().setSpeed(speed));
+        if (player.isPlaying()) {
+          player.setPlaybackParams(player.getPlaybackParams().setSpeed(speed));
+        } else {
+          player.setPlaybackParams(player.getPlaybackParams().setSpeed(speed));
+          player.pause();
+        }
       }
     }
   }


### PR DESCRIPTION
* Fix auto-playing as setting speed
* As the android official document, after the player is prepared, calling it with non-zero speed is equivalent to calling start().
* Implementation example: http://www.wallacezhen.com/index.php/2017/07/04/android-mediaplayer-set-playback-speed/