### PR TITLE
Add onPlay event emitter

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -47,6 +47,9 @@
   if (key == nil) return;
 
   @synchronized(key) {
+    if (!flag) {
+      [self setOnPlay:flag forKey:key];
+    }
     RCTResponseSenderBlock callback = [self callbackForKey:key];
     if (callback) {
       callback(@[@(flag)]);
@@ -59,7 +62,7 @@ RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"RouteChange"];
+    return @[@"RouteChange", @"onPlayChange"];
 }
 
 -(NSDictionary *)constantsToExport {
@@ -196,6 +199,7 @@ RCT_EXPORT_METHOD(play:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBlo
   if (player) {
     [[self callbackPool] setObject:[callback copy] forKey:key];
     [player play];
+    [self setOnPlay:YES forKey:key];
   }
 }
 
@@ -303,6 +307,11 @@ RCT_REMAP_METHOD(isHeadsetPlugged,
     BOOL headsetPlugged = [self isHeadsetPlugged];
 
     [self sendEventWithName:@"RouteChange" body:@{@"isHeadsetPlugged": headsetPlugged ? @YES : @NO}];
+}
+
+- (void)setOnPlay:(BOOL)isPlaying forKey:(nonnull NSNumber*)key {
+
+    [self sendEventWithName:@"onPlayChange" body:@{@"isPlaying": isPlaying ? @YES : @NO, @"key": key}];
 }
 
 RCT_EXPORT_METHOD(addRouteChangeListener) {

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -291,7 +291,7 @@ RCT_REMAP_METHOD(isHeadsetPlugged,
 
 - (BOOL)isHeadsetPlugged {
     AVAudioSessionRouteDescription *route = [[AVAudioSession sharedInstance] currentRoute];
-    
+
     BOOL headphonesLocated = NO;
     for( AVAudioSessionPortDescription *portDescription in route.outputs ) {
         headphonesLocated |= ( [portDescription.portType isEqualToString:AVAudioSessionPortHeadphones] );
@@ -317,18 +317,6 @@ RCT_EXPORT_METHOD(removeRouteChangeListener) {
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                   name:@"AVAudioSessionRouteChangeNotification"
                                                 object: [AVAudioSession sharedInstance]];
-}
-
-RCT_REMAP_METHOD(isPlaying,
-                 playerKey:(nonnull NSNumber*)key
-                 resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
-  AVAudioPlayer* player = [self playerForKey:key];
-  if (player) {
-    resolve(@(player.isPlaying));
-  } else {
-    resolve(@(false));
-  }
 }
 
 @end

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -47,7 +47,7 @@
   if (key == nil) return;
 
   @synchronized(key) {
-    [self setOnPlay:NO forKey:key];
+    [self setOnPlay:NO forPlayerKey:key];
     RCTResponseSenderBlock callback = [self callbackForKey:key];
     if (callback) {
       callback(@[@(flag)]);
@@ -197,7 +197,7 @@ RCT_EXPORT_METHOD(play:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBlo
   if (player) {
     [[self callbackPool] setObject:[callback copy] forKey:key];
     [player play];
-    [self setOnPlay:YES forKey:key];
+    [self setOnPlay:YES forPlayerKey:key];
   }
 }
 
@@ -307,9 +307,9 @@ RCT_REMAP_METHOD(isHeadsetPlugged,
     [self sendEventWithName:@"RouteChange" body:@{@"isHeadsetPlugged": headsetPlugged ? @YES : @NO}];
 }
 
-- (void)setOnPlay:(BOOL)isPlaying forKey:(nonnull NSNumber*)key {
+- (void)setOnPlay:(BOOL)isPlaying forPlayerKey:(nonnull NSNumber*)playerKey {
 
-    [self sendEventWithName:@"onPlayChange" body:@{@"isPlaying": isPlaying ? @YES : @NO, @"key": key}];
+    [self sendEventWithName:@"onPlayChange" body:@{@"isPlaying": isPlaying ? @YES : @NO, @"playerKey": playerKey}];
 }
 
 RCT_EXPORT_METHOD(addRouteChangeListener) {

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -47,9 +47,7 @@
   if (key == nil) return;
 
   @synchronized(key) {
-    if (!flag) {
-      [self setOnPlay:NO forKey:key];
-    }
+    [self setOnPlay:NO forKey:key];
     RCTResponseSenderBlock callback = [self callbackForKey:key];
     if (callback) {
       callback(@[@(flag)]);

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -48,7 +48,7 @@
 
   @synchronized(key) {
     if (!flag) {
-      [self setOnPlay:flag forKey:key];
+      [self setOnPlay:NO forKey:key];
     }
     RCTResponseSenderBlock callback = [self callbackForKey:key];
     if (callback) {

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -222,8 +222,8 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   public void play(final Integer key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player == null) {
-      callback.invoke(false);
       setOnPlay(false, key);
+      callback.invoke(false);
       return;
     }
     if (player.isPlaying()) {
@@ -235,11 +235,11 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       @Override
       public synchronized void onCompletion(MediaPlayer mp) {
         if (!mp.isLooping()) {
+          setOnPlay(false, key);
           if (callbackWasCalled) return;
           callbackWasCalled = true;
           try {
             callback.invoke(true);
-            setOnPlay(false, key);
           } catch (Exception e) {
               //Catches the exception: java.lang.RuntimeException·Illegal callback invocation from native module
           }
@@ -251,10 +251,10 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
 
       @Override
       public synchronized boolean onError(MediaPlayer mp, int what, int extra) {
+        setOnPlay(false, key);
         if (callbackWasCalled) return true;
         callbackWasCalled = true;
         callback.invoke(false);
-        setOnPlay(false, key);
         return true;
       }
     });

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -44,10 +44,11 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     this.category = null;
   }
 
-  private void setOnPlay(boolean isPlaying) {
+  private void setOnPlay(boolean isPlaying, final Integer key) {
     final ReactContext reactContext = this.context;
     WritableMap params = Arguments.createMap();
     params.putBoolean("isPlaying", isPlaying);
+    params.putInt("key", key);
     sendEvent(reactContext, "onPlayChange", params);
   }
 
@@ -222,7 +223,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     MediaPlayer player = this.playerPool.get(key);
     if (player == null) {
       callback.invoke(false);
-      setOnPlay(false);
+      setOnPlay(false, key);
       return;
     }
     if (player.isPlaying()) {
@@ -238,7 +239,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
           callbackWasCalled = true;
           try {
             callback.invoke(true);
-            setOnPlay(false);
+            setOnPlay(false, key);
           } catch (Exception e) {
               //Catches the exception: java.lang.RuntimeException·Illegal callback invocation from native module
           }
@@ -253,12 +254,12 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
         if (callbackWasCalled) return true;
         callbackWasCalled = true;
         callback.invoke(false);
-        setOnPlay(false);
+        setOnPlay(false, key);
         return true;
       }
     });
     player.start();
-    setOnPlay(true);
+    setOnPlay(true, key);
   }
 
   @ReactMethod

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -44,11 +44,11 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     this.category = null;
   }
 
-  private void setOnPlay(boolean isPlaying, final Integer key) {
+  private void setOnPlay(boolean isPlaying, final Integer playerKey) {
     final ReactContext reactContext = this.context;
     WritableMap params = Arguments.createMap();
     params.putBoolean("isPlaying", isPlaying);
-    params.putInt("key", key);
+    params.putInt("playerKey", playerKey);
     sendEvent(reactContext, "onPlayChange", params);
   }
 

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -44,6 +44,13 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     this.category = null;
   }
 
+  private void setOnPlay(boolean isPlaying) {
+    final ReactContext reactContext = this.context;
+    WritableMap params = Arguments.createMap();
+    params.putBoolean("isPlaying", isPlaying);
+    sendEvent(reactContext, "onPlayChange", params);
+  }
+
   @Override
   public String getName() {
     return "RNSound";
@@ -83,7 +90,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
 
     final RNSoundModule module = this;
     final int audioStreamTypeFinal = audioStreamType;
-    
+
     if (module.category != null) {
       Integer category = null;
       switch (module.category) {
@@ -215,6 +222,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     MediaPlayer player = this.playerPool.get(key);
     if (player == null) {
       callback.invoke(false);
+      setOnPlay(false);
       return;
     }
     if (player.isPlaying()) {
@@ -230,6 +238,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
           callbackWasCalled = true;
           try {
             callback.invoke(true);
+            setOnPlay(false);
           } catch (Exception e) {
               //Catches the exception: java.lang.RuntimeException·Illegal callback invocation from native module
           }
@@ -244,10 +253,12 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
         if (callbackWasCalled) return true;
         callbackWasCalled = true;
         callback.invoke(false);
+        setOnPlay(false);
         return true;
       }
     });
     player.start();
+    setOnPlay(true);
   }
 
   @ReactMethod
@@ -375,16 +386,6 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void enable(final Boolean enabled) {
     // no op
-  }
-
-  @ReactMethod
-  public void isPlaying(final Integer key, Promise promise) {
-    MediaPlayer player = this.playerPool.get(key);
-    if (player != null) {
-      promise.resolve(player.isPlaying());
-    } else {
-      promise.resolve(false);
-    }
   }
 
   private void sendEvent(ReactContext reactContext,

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare class Sound {
    * Register a listener for changes of headsetPluggedIn
    */
   static registerHeadsetPlugChangeListener(): void
-  
+
   /**
    * Unregister the attached listener for changes of headsetPluggedIn
    */
@@ -82,7 +82,7 @@ declare class Sound {
    * @param filename Either absolute or relative path to the sound file
    * @param basePath Optional base path of the file. Omit this or pass '' if filename is an absolute path. Otherwise, you may use one of the predefined directories: Sound.MAIN_BUNDLE, Sound.DOCUMENT, Sound.LIBRARY, Sound.CACHES.
    * @param onError Optional callback function if loading file failed
-   * @param options Optional feature 
+   * @param options Optional feature
    */
   constructor(filename: string, basePath: string, onError: (error: any) => void, options: { audioStreamType: AudioManagerAudioStreamType })
 
@@ -129,7 +129,7 @@ declare class Sound {
    * Return the time of audio (second)
    */
   getDuration(): number
-  
+
   /**
    * Return the volume of the audio player (not the system-wide volume),
    * Ranges from 0.0 (silence) through 1.0 (full volume, the default)
@@ -207,9 +207,20 @@ declare class Sound {
   setSpeakerphoneOn(value: boolean): void
 
   /**
-   * Return promise with isPlaying.
+   * Return whether the audio player is currently playing or not
    */
-  isPlaying(): Promise<boolean>
+  isPlaying(): boolean
+
+    /**
+   * Register a on start playing listener
+   */
+  registerOnPlayListener(): void
+
+  /**
+   * Unregister the attached on start playing listener
+   */
+  unregisterOnPlayListener(): void
+
 }
 
 export = Sound;

--- a/index.d.ts
+++ b/index.d.ts
@@ -210,17 +210,6 @@ declare class Sound {
    * Return whether the audio player is currently playing or not
    */
   isPlaying(): boolean
-
-    /**
-   * Register a on start playing listener
-   */
-  registerOnPlayListener(): void
-
-  /**
-   * Unregister the attached on start playing listener
-   */
-  unregisterOnPlayListener(): void
-
 }
 
 export = Sound;

--- a/sound.js
+++ b/sound.js
@@ -27,6 +27,7 @@ function Sound(filename, basePath, onError, options) {
   }
 
   this._loaded = false;
+  this._playing = false;
   this._key = nextKey++;
   this._duration = -1;
   this._numberOfChannels = -1;
@@ -60,6 +61,7 @@ Sound.prototype.play = function(onEnd) {
     if (IsAndroid) {
       RNSound.setSpeed(this._key, this._speed);
     }
+    this._playing = true;
   }
   else {
     onEnd && onEnd(false);
@@ -74,6 +76,7 @@ Sound.prototype.pause = function(callback) {
   if (this._loaded) {
     RNSound.pause(this._key, () => { callback && callback() });
   }
+  this._playing = false;
   return this;
 };
 
@@ -81,6 +84,7 @@ Sound.prototype.stop = function(callback) {
   if (this._loaded) {
     RNSound.stop(this._key, () => { callback && callback() });
   }
+  this._playing = false;
   return this;
 };
 
@@ -88,6 +92,7 @@ Sound.prototype.reset = function() {
   if (this._loaded && IsAndroid) {
     RNSound.reset(this._key);
   }
+  this._playing = false;
   return this;
 };
 
@@ -170,13 +175,10 @@ Sound.prototype.setSpeed = function(value) {
   if (this._loaded) {
     if (!IsWindows && !IsAndroid) {
         RNSound.setSpeed(this._key, value);
-    }else if (IsAndroid) {
-      const isPlayingPromise = RNSound.isPlaying(this._key);
-      isPlayingPromise.then((result) => {
-        if (result) {
-          RNSound.setSpeed(this._key, value);
-        }
-      });
+    } else if (IsAndroid) {
+      if(this._isPlaying) {
+        RNSound.setSpeed(this._key, value);
+      }
     }
   }
   return this;

--- a/sound.js
+++ b/sound.js
@@ -209,9 +209,9 @@ Sound.prototype.setSpeed = function(value) {
     if (!IsWindows && !IsAndroid) {
       RNSound.setSpeed(this._key, value);
     } else if (IsAndroid) {
-      if(this._playing) {
-        RNSound.setSpeed(this._key, value);
-      }
+        if(this._playing) {
+          RNSound.setSpeed(this._key, value);
+        }
     }
   }
   return this;

--- a/sound.js
+++ b/sound.js
@@ -176,7 +176,7 @@ Sound.prototype.setSpeed = function(value) {
     if (!IsWindows && !IsAndroid) {
         RNSound.setSpeed(this._key, value);
     } else if (IsAndroid) {
-      if(this._isPlaying) {
+      if(this._playing) {
         RNSound.setSpeed(this._key, value);
       }
     }

--- a/sound.js
+++ b/sound.js
@@ -210,7 +210,7 @@ Sound.prototype.setSpeed = function(value) {
     if (!IsWindows && !IsAndroid) {
       RNSound.setSpeed(this._key, value);
     } else if (IsAndroid) {
-      //For Android
+      // For Android
       // Call native setSpeed method only if the media player is already playing.
       // To prevent android from playing automatically when setSpeed is called.
       if (this._playing) {

--- a/sound.js
+++ b/sound.js
@@ -208,6 +208,8 @@ Sound.prototype.setSpeed = function(value) {
   if (this._loaded) {
     if (!IsWindows && !IsAndroid) {
       RNSound.setSpeed(this._key, value);
+    // Call native setSpeed method only if the media player is already playing.
+    // To prevent android from playing automatically when setSpeed is called.
     } else if (IsAndroid) {
         if(this._playing) {
           RNSound.setSpeed(this._key, value);

--- a/sound.js
+++ b/sound.js
@@ -57,9 +57,16 @@ Sound.prototype.isLoaded = function() {
 Sound.prototype.play = function(onEnd) {
   if (this._loaded) {
     RNSound.play(this._key, (successfully) => onEnd && onEnd(successfully));
-  } else {
+    if (IsAndroid) {
+      RNSound.setSpeed(this._key, this._speed);
+    }
+  }
+  else {
     onEnd && onEnd(false);
   }
+
+
+
   return this;
 };
 
@@ -159,9 +166,17 @@ Sound.prototype.setNumberOfLoops = function(value) {
 
 Sound.prototype.setSpeed = function(value) {
   this._setSpeed = value;
+  this._speed = value;
   if (this._loaded) {
-    if (!IsWindows) {
-      RNSound.setSpeed(this._key, value);
+    if (!IsWindows && !IsAndroid) {
+        RNSound.setSpeed(this._key, value);
+    }else if (IsAndroid) {
+      const isPlayingPromise = RNSound.isPlaying(this._key);
+      isPlayingPromise.then((result) => {
+        if (result) {
+          RNSound.setSpeed(this._key, value);
+        }
+      });
     }
   }
   return this;
@@ -239,7 +254,7 @@ Sound.unregisterHeadsetPlugChangeListener = function() {
       this.headsetPluggedInSubscription = null;
     }
   }
-  
+
 }
 
 // ios only

--- a/sound.js
+++ b/sound.js
@@ -23,14 +23,16 @@ const registerOnPlay = function(onPlayListener) {
     this.onPlaySubscription = eventEmitter.addListener(
       'onPlayChange',
       (param) => {
-        const { isPlaying } = param;
-        if (isPlaying) {
-          this._playing = true;
+        const { isPlaying, key } = param;
+        if (key == this._key) {
+          if (isPlaying) {
+            this._playing = true;
+          }
+          else {
+            this._playing = false;
+          }
+          onPlayListener && onPlayListener(isPlaying);
         }
-        else {
-          this._playing = false;
-        }
-        onPlayListener && onPlayListener(isPlaying);
       },
     );
   }


### PR DESCRIPTION
## Issue
- It closes #30  .

## Changes
- For android, do not directly call `setSpeed()` native function if the player is not playing.
- Make new global variable `this._playing` which saves current playing status.
- Add `onPlay` event emitter that fires an event whenever native `play()` method gets called.
- `onPlay` event emitter is implicitly registered when Media Player gets prepared.
- `onPlay` event emitter can be explicitly registered with user defined function.