### PR TITLE
Support to control volume of player android

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -21,7 +21,6 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.facebook.react.modules.core.ExceptionsManagerModule;
 
 import java.io.File;
 import java.util.HashMap;
@@ -37,7 +36,6 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   final static Object NULL = null;
   BroadcastReceiver broadcastReceiverHeadsetPlugged = null;
   String category;
-  private static final String TAG = "ReactNativeJS";
   private AudioManager am;
 
   public RNSoundModule(ReactApplicationContext context) {
@@ -60,61 +58,6 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     return "RNSound";
   }
 
-  // @ReactMethod
-  // public void getAudioFocus(final Callback callback) {
-  //   am.requestAudioFocus(new AudioManager.OnAudioFocusChangeListener() {
-  //     boolean callbackWasCalled = false;
-  //     @Override
-  //     public void onAudioFocusChange(int focusChange) {
-  //       if (callbackWasCalled) return;
-  //       callbackWasCalled = true;
-  //       Log.d(TAG, "audio change: " + focusChange);
-  //       // if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
-
-  //       // } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
-
-  //       // } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT) {
-
-  //       // } else if (focusChange == AudioManagner.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
-
-  //       // }
-  //       try {
-  //         callback.invoke(focusChange);
-  //       } catch(RuntimeException runtimeException) {
-  //         // The callback was already invoked
-  //         Log.e("RNSoundModule", "Exception", runtimeException);
-  //       }
-  //     }
-  //   }, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE);
-  // }
-
-  // @ReactMethod
-  // public void abandonAudioFocus(final Callback callback) {
-  //   am.abandonAudioFocus(new AudioManager.OnAudioFocusChangeListener() {
-  //     boolean callbackWasCalled = false;
-
-  //     @Override
-  //     public void onAudioFocusChange(int focusChange) {
-  //       if (callbackWasCalled) return;
-  //       callbackWasCalled = true;
-  //       // if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
-
-  //       // } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
-
-  //       // } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT) {
-
-  //       // } else if (focusChange == AudioManagner.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
-
-  //       // }
-  //       try {
-  //         callback.invoke(focusChange);
-  //       } catch(RuntimeException runtimeException) {
-  //         // The callback was already invoked
-  //         Log.e("RNSoundModule", "Exception", runtimeException);
-  //       }
-  //     }
-  //   });
-  // }
   @ReactMethod
   public void prepare(final String fileName, final Integer key, final ReadableMap options, final Callback callback) {
     int audioStreamType = AudioManager.STREAM_MUSIC;
@@ -346,12 +289,11 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void reset(final Integer key, final Callback callback) {
+  public void reset(final Integer key) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {
       player.reset();
     }
-    callback.invoke();
   }
 
   @ReactMethod

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,6 +92,12 @@ declare class Sound {
   isLoaded(): boolean
 
   /**
+   * @param onError Optional callback function if loading file failed
+   * @param streamType streamType
+   */
+  setStreamType(streamType: { audioStreamType: AudioManagerAudioStreamType }, onError: (error: any) => void)
+
+  /**
    * Plays the loaded file
    * @param onEnd - Optional callback function that gets called when the playback finishes successfully or an audio decoding error interrupts it
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,7 +95,7 @@ declare class Sound {
    * @param onError Optional callback function if loading file failed
    * @param streamType streamType
    */
-  setStreamType(streamType: { audioStreamType: AudioManagerAudioStreamType }, onError: (error: any) => void)
+  setStreamType(streamType: AudioManagerAudioStreamType, onError: (error: any) => void)
 
   /**
    * Plays the loaded file

--- a/sound.js
+++ b/sound.js
@@ -119,9 +119,11 @@ Sound.prototype.stop = function(callback) {
 
 Sound.prototype.setStreamType = function(streamType, callback) {
   // For android only.
-  // Resets current mediaPlayer, change streamType, and prepare again.
-  if (IsAndroid) {
-    if (!this._loaded) {
+  // resets current media player, sets streamType, and prepare again.
+  if (IsAndroid && this._loaded) {
+    RNSound.reset(this._key, () => {
+      this._playing = false;
+      this._loaded = false;
       RNSound.prepare(this._filename, this._key, streamType || {}, (error, props) => {
         if (props) {
           if (typeof props.duration === 'number') {
@@ -136,7 +138,7 @@ Sound.prototype.setStreamType = function(streamType, callback) {
           callback && callback();
         }
       });
-    }
+    });
   }
 }
 

--- a/sound.js
+++ b/sound.js
@@ -117,10 +117,36 @@ Sound.prototype.stop = function(callback) {
   return this;
 };
 
-Sound.prototype.reset = function() {
+Sound.prototype.setStreamType = function(streamType, callback) {
+  // For android only.
+  // Resets current mediaPlayer, change streamType, and prepare again.
+  if (IsAndroid) {
+    if (!this._loaded) {
+      RNSound.prepare(this._filename, this._key, streamType || {}, (error, props) => {
+        if (props) {
+          if (typeof props.duration === 'number') {
+            this._duration = props.duration;
+          }
+          if (typeof props.numberOfChannels === 'number') {
+            this._numberOfChannels = props.numberOfChannels;
+          }
+        }
+        if (error === null) {
+          this._loaded = true;
+          callback && callback();
+        }
+      });
+    }
+  }
+}
+
+Sound.prototype.reset = function(callback) {
   if (this._loaded && IsAndroid) {
-    RNSound.reset(this._key);
-    this._playing = false;
+    RNSound.reset(this._key, () => {
+      this._playing = false;
+      this._loaded = false;
+      callback && callback();
+    });
   }
   return this;
 };


### PR DESCRIPTION
## Issue
- This PR is related to https://github.com/hayanmind/mimiking-rn/issues/1285

## Changes
- Add `setStreamType()` functionality for Android

## Logic
- `setStreamType()` resets mediaPlayer, changes its streamType, and then reprepares.
- `prepare()` no longer makes new mediaPlayer everytime it is called.

## Refactoring
- This PR has been refactored by @ghsdh3409 with #34 .