### PR TITLE
Make setSpeakerphoneOn be static method for iOS

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -279,8 +279,6 @@ Sound.prototype.setCurrentTime = function(value) {
 Sound.prototype.setSpeakerphoneOn = function(value) {
   if (IsAndroid) {
     RNSound.setSpeakerphoneOn(this._key, value);
-  } else if (!IsAndroid && !IsWindows) {
-    RNSound.setSpeakerphoneOn(value);
   }
 };
 
@@ -359,6 +357,12 @@ Sound.setActive = function(value) {
 Sound.setCategory = function(value, mixWithOthers = false, allowBluetooth = false) {
   if (!IsAndroid && !IsWindows) {
     RNSound.setCategory(value, mixWithOthers, allowBluetooth);
+  }
+};
+
+Sound.setSpeakerphoneOn = function(value) {
+  if (!IsAndroid && !IsWindows) {
+    RNSound.setSpeakerphoneOn(value);
   }
 };
 

--- a/sound.js
+++ b/sound.js
@@ -279,6 +279,8 @@ Sound.prototype.setCurrentTime = function(value) {
 Sound.prototype.setSpeakerphoneOn = function(value) {
   if (IsAndroid) {
     RNSound.setSpeakerphoneOn(this._key, value);
+  } else if (!IsAndroid && !IsWindows) {
+    console.wran('Use static method Sound.setSpeakerphoneOn() instead for iOS!')
   }
 };
 
@@ -360,7 +362,7 @@ Sound.setCategory = function(value, mixWithOthers = false, allowBluetooth = fals
   }
 };
 
-Sound.setSpeakerphoneOn = function(value) {
+Sound.setSpeakerphoneOnIos = function(value) {
   if (!IsAndroid && !IsWindows) {
     RNSound.setSpeakerphoneOn(value);
   }


### PR DESCRIPTION
* It closes #40.
* Simple change. It is expected to takes under 5 min.
* iOS setSpeakerphoneOn can works without a player initialized. Thus, this method should be located under module object not in prototype.